### PR TITLE
Fix bug in checkPass function: Message passwordIncorrect was not send.

### DIFF
--- a/index.js
+++ b/index.js
@@ -137,6 +137,7 @@ server.bind(
                 "use strict";
                 if (error) {
                     console.log("AUTH ERROR for " + login + ": " + error);
+                    return next(new ldap.InvalidCredentialsError());
                     } 
                 else {
                     if (response == "passwordIncorrect") {
@@ -155,9 +156,6 @@ server.bind(
                 return next();
                 }
             );            
-        
-        res.end();
-        return next();
         }
     );
 


### PR DESCRIPTION
The commands ``res.end();`` and ``return next();`` beneath the function ``checkPass`` are executed before the password is checked. This results in a false positive answer, accepting wrong passwords.

In the function ``checkPass`` there is a check if there was an error in the authentification module. This check is fine, but no result was send to the client. This as well results in a false positive answer, accepting wrong passwords.

Please consider my attached changes.

